### PR TITLE
Version 0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
-## [0.3.0] - 2024-06-25
+## [0.3.0] - 2024-06-26
 
 ### Added
 - New units context manager function `core.units` that allows users to load unit-based functionality and then run checks using context `from pysb.units import units; with units():`. The context manager applies the `unitize` and `check` functions automatically so users don't need to do it manually. 
+- Optional `unit` argument for `Parameter` that allows unit specification when initializing a new model parameter: `Parameter(...,..., unit="...")` which is equivalent to `Unit(Parameter(..,..) "unit"))`.
+- New `examples` sub-package with:
+    - unit-ed version of `bngwiki_simple` model - adpated from `pysb.examples.bngwiki_simple`.
+    - unit-ed version of the `jnk3_no_ask1` model - adpated from the `JARM/model_analysis/jnk3_no_ask1.py` model.
+
+### Fixed
+- Problem converting composite units with molar concentrations to their equivalent with number of molecules and updating the associated parameter. Updated the `ParameterUnit.convert` function to account for this.
+- Problem in the string repr for Parameters with units set to `None`, as well as the processing in ParameterUnit that now skips the conversion related to `SimulationUnits` settings when the input unit is `None`. 
 
 ## [0.2.0] - 2024-06-20
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [0.3.0] - 2024-06-25
+
+### Added
+- New units context manager function `core.units` that allows users to load unit-based functionality and then run checks using context `from pysb.units import units; with units():`. The context manager applies the `unitize` and `check` functions automatically so users don't need to do it manually. 
+
 ## [0.2.0] - 2024-06-20
 
 ### Added

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,10 @@
+cff-version: 1.2.0
+message: "If this software is useful for your work, I'd appreciate if you cited it as below."
+authors:
+- family-names: "Wilson"
+  given-names: "Blake"
+  orcid: "https://orcid.org/0000-0002-8269-2500"
+title: "pysb-units: Add-on for units and dimensional analysis in PySB models."
+version: 0.3.0
+date-released: 2024-06-26
+url: "https://github.com/Borealis-BioModeling/pysb-units"

--- a/README.md
+++ b/README.md
@@ -98,6 +98,7 @@ __pysb-units__ introduces two new objects for defining and managing units in a p
 
  * `Unit(component, 'unit')`- assigns a particular unit value to a model component such as Parameter or Observable. E.g., to assign a frequency unit to a rate constant parameter (as a single line): `Unit(Parameter('k_f', 1e-1), '1/s')`. This object is derived from pysb's `Annotation` object but leverages the `astropy.units` library for unit management.
     * You can explicity define dimensionless quantities by passing `None` for the input units: e.g., `Unit(scaling_factor, None)`.
+    `Parameter`s accept an optional keyword `unit` that can be used to assign a `Unit` that parameter automatically with needing to explicity attach the `Unit` object.
  * `SimulationUnits(concentration='concentration_unit', time='time_unit')` - sets the concentration and time units that are to be used in simulations. E.g., to set the use of nM concentrations and time in seconds: `SimulationUnits(concentration='nM', time='s')`. Note that when this object is defined it will enforce conversion of all concentration and time units to the specified units.
    * Supports stochastic simulation units with `concentration='molecules'`; it uses a unit conversion based on the equation `molecules = [molar concentraion] * volume * N_A`, where N_A is Avogadro's number. 
    * To define the appropriate volume for the conversion a call to the `pysb.units.set_molecule_volume(value[float], unit[str])` can be added before or just after the `SimulationUnits` initialization. E.g., `pysb.units.set_molecule_volume(1.6, 'pL')` would set a volume of 1.6 pL for the conversion used by `SimulationUnits` to go from molar concentrations to number of molecules. **Note** that these conversions currently only work properly for non-compartmental models. 
@@ -108,6 +109,9 @@ __pysb-units__ introduces two new objects for defining and managing units in a p
 ### Example
 
 A simple model with one degradation reaction:
+
+
+
 
 * Regular pysb:
 ```python
@@ -407,6 +411,41 @@ units.check()
 Now, when `Unit(protein_0, 'uM)` is evaluated the concentration of 500 micromolar will be automatically converted to the number of molecules ('molecules' unit).
 
 Note that at the moment, this approach only works for non-compartmental models.
+
+## unit keyword for Parameter
+
+The `Parameter` component can accept an optional keyword argument for the `unit`, which means you can define the unit along with the parameter without explicitly applying a `Unit` object to the parameter. So, you can define unit-ed parameters using something like (as of version 0.3.0)
+```python
+Parameter('k_r', 0.1, unit="1/s")
+```
+instead of doing (earlier versions)
+```python
+Unit(Parameter('k_r', 0.1), '1/s')
+```
+
+The outcome is the same either way, but the top version is a little more compact and easier to read. 
+
+# Accessing all the Units for a model
+
+You can get a list of `Unit` objects defined for a model with the `Model.units` property:
+```python
+from my_model_with_units import model
+print(model.units)
+```
+
+## Additional Examples
+
+Additional examples can be found in or imported from [pysb.units.examples](./src/pysb/units/examples), including 
+
+* [bngwiki_simple](./src/pysb/units/examples/bngwiki_simple.py). - adapted from pysb example [pysb.examples.bngwiki_simple](https://github.com/pysb/pysb/blob/master/pysb/examples/bngwiki_simple.py): 
+ ```python
+ from pysb.units.examples.bngwiki_simple import model
+ ``` 
+ * [jnk3_no_ask1](./src/pysb/units/examples/jnk3_no_ask1.py). - adapted from JARM [jnk3_no_ask1](https://github.com/LoLab-MSM/JARM/blob/master/model_analysis/jnk3_no_ask1.py): 
+ ```python
+ from pysb.units.examples.jnk3_no_ask1 import model
+ ``` 
+
 
 ## Custom Units
 

--- a/README.md
+++ b/README.md
@@ -3,8 +3,8 @@
 ![Python version badge](https://img.shields.io/badge/python-3.11.3-blue.svg)
 [![PySB version badge](https://img.shields.io/badge/PySB->%3D1.15.0-9cf.svg)](https://pysb.org/)
 [![license](https://img.shields.io/github/license/Borealis-BioModeling/pysb-units.svg)](LICENSE)
-![version](https://img.shields.io/badge/version-0.2.0-orange.svg)
-[![release](https://img.shields.io/github/release-pre/Borealis-BioModeling/pysb-units.svg)](https://github.com/Borealis-BioModeling/pysb-units/releases/tag/v0.2.0)
+![version](https://img.shields.io/badge/version-0.3.0-orange.svg)
+[![release](https://img.shields.io/github/release-pre/Borealis-BioModeling/pysb-units.svg)](https://github.com/Borealis-BioModeling/pysb-units/releases/tag/v0.3.0)
 
 `pysb-units` is an add-on for the [PySB](https://pysb.org/) modeling framework that provides tools to add units to models. 
 
@@ -45,27 +45,27 @@ Note that `pysb-units` has the following core dependencies:
 
 ### pip install
 
-You can install `pysb-units` version 0.2.0 with `pip` sourced from the GitHub repo:
+You can install `pysb-units` version 0.3.0 with `pip` sourced from the GitHub repo:
 
 ##### with git installed:
 
 Fresh install:
 ```
-pip install git+https://github.com/Borealis-BioModeling/pysb-units@v0.2.0
+pip install git+https://github.com/Borealis-BioModeling/pysb-units@v0.3.0
 ```
 Or to upgrade from an older version:
 ```
-pip install --upgrade git+https://github.com/Borealis-BioModeling/pysb-units@v0.2.0
+pip install --upgrade git+https://github.com/Borealis-BioModeling/pysb-units@v0.3.0
 ```
 ##### without git installed:
 
 Fresh install:
 ```
-pip install https://github.com/Borealis-BioModeling/pysb-units/archive/refs/tags/v0.2.0.zip
+pip install https://github.com/Borealis-BioModeling/pysb-units/archive/refs/tags/v0.3.0.zip
 ```
 Or to upgrade from an older version:
 ```
-pip install --upgrade https://github.com/Borealis-BioModeling/pysb-units/archive/refs/tags/v0.2.0.zip
+pip install --upgrade https://github.com/Borealis-BioModeling/pysb-units/archive/refs/tags/v0.3.0.zip
 ```
 ### Manual install
 
@@ -210,7 +210,65 @@ inverse time (i.e., frequency) units: [1 /  time], such as, [1 / s] or [1 / h].
  * `Expression('deg_rate', (protein_t * k_deg))` - units of expressions are automatically inferred from the units of parameters and observables, so in this case the Expression will have units of 'uM/s'.
  * `units.check()` - this function applies additional unit checking and will issue warnings for duplicate units (two different units assigned to the same parameter), lack of consistency for units of the same physical type (e.g., concentration, time, etc.), and parameters without any 
 
+## units context manager
 
+In the previous example we added explicit calls to 
+the `unitize` and `check` functions. If you prefer, you can use the `units` context manager instead to achieve the same effects:
+
+```python
+# Import the pysb components we need:
+from pysb import Model, Parameter, Monomer, Initial, Observable, Expression
+# Import the pysb-units context manager:
+from pysb.units import units
+
+# Activate units using the units context manager - 
+# replaces core model components with the appropriate 
+# versions from pysb.units (similar to unitize) and will 
+# automatically call the check function when exiting the
+# context:
+with units():
+
+    # Initialize the PySB model:
+    Model()
+
+    # The primary units needed for simulating the model are 
+    # concentration (or amount) and time. We can define those
+    # here with SimulationUnits:
+    SimulationUnits(concentration='uM', time='s')
+
+    # Monomer(s):
+    Monomer('protein')
+
+    # Model parameter(s):
+    # Initial concentration of protein:
+    Parameter('protein_0', 500.)
+    # Attach units to protein_0:
+    Unit(protein_0, 'nM')
+
+
+    # 1st-order rate parameter for the degradation
+    # defined with frequency (1/time) units - here, 
+    # we chain Unit and Parameter definitions:
+    Unit(Parameter('k_deg', 0.1), '1/s') 
+
+
+    # Initial concentration(s)
+    Initial(protein, protein_0)
+
+
+    # Reaction rule(s)
+    # Just the one degradation
+    Rule('degradation', protein() >> None, k_deg)
+
+    # Observables
+    # Time-dependent protein concentration:
+    Observable('protein_t', protein())
+
+    # Expressions
+    # The time-dependent degradation rate:
+    Expression('deg_rate', (protein_t * k_deg))
+
+```
 
 ## Using units with pysb.macros
 
@@ -377,7 +435,7 @@ report any problems/bugs or make any comments, suggestions, or feature requests.
 If this package is useful in your work, please cite in any publications:
 
 ```
-Blake A. Wilson. (2024). pysb-units. (v0.2.0). https://github.com/Borealis-BioModeling/pysb-units
+Blake A. Wilson. (2024). pysb-units. (v0.3.0). https://github.com/Borealis-BioModeling/pysb-units
 ```
 
 -----

--- a/README.md
+++ b/README.md
@@ -19,8 +19,13 @@
  4. [Documentation and Usage](#documentation-and-usage)
      1. [Quick Overview](#quick-overview)
      2. [Example](#example)
-     3. [List of macros](#list-of-macros)
-     4. [Preconstructed models](#preconstructed-models)
+     3. [units context manager](#units-context-manager)
+     4. [Using units with pysb.macros](#using-units-with-pysbmacros)
+     5. [Stochastic Simulation Units](#stochastic-simulation-units)
+     6. [unit keyword for Parameter](#unit-keyword-for-parameter)
+     7. [Accessing Model units](#accessing-all-the-units-for-a-model)
+     8. [Additional Examples](#additional-examples)
+     9. [Custom Units](#custom-units)
  5. [Contact](#contact)
  6. [Citing](#citing)  
  7. [Other Useful Tools](#other-useful-tools)
@@ -425,7 +430,7 @@ Unit(Parameter('k_r', 0.1), '1/s')
 
 The outcome is the same either way, but the top version is a little more compact and easier to read. 
 
-# Accessing all the Units for a model
+## Accessing all the Units for a model
 
 You can get a list of `Unit` objects defined for a model with the `Model.units` property:
 ```python

--- a/src/pysb/units/__init__.py
+++ b/src/pysb/units/__init__.py
@@ -13,4 +13,4 @@ def set_molecule_volume(value: float, unit: str) -> None:
     return
 
 
-__version__ = '0.2.0'
+__version__ = '0.3.0'

--- a/src/pysb/units/__init__.py
+++ b/src/pysb/units/__init__.py
@@ -8,9 +8,5 @@ try:
 except:
     pass
 
-def set_molecule_volume(value: float, unit: str) -> None:
-    unitdefs.set_molecule_volume(value, unit)
-    return
-
 
 __version__ = '0.3.0'

--- a/src/pysb/units/examples/bngwiki_simple.py
+++ b/src/pysb/units/examples/bngwiki_simple.py
@@ -1,0 +1,63 @@
+"""Updated version of the pysb bngwiki_simple example model with units.
+
+Units features are from the pysb-units add-on.
+
+Adapted from:
+https://github.com/pysb/pysb/blob/master/pysb/examples/bngwiki_simple.py
+"""
+
+from __future__ import print_function
+from pysb import *
+from pysb.units import units
+
+# Define the model inside the units context for
+# pysb.units features. This includes SimulationUnits and Unit objects and
+# the set_molecule_volume function. Upon exiting the units context the
+# pysb.units.check function is executed to evaluate any potential issues with
+# the units, including checking for duplicate Unit objects, unit consistency,
+# or potentially missing units).
+with units():
+
+    Model()
+
+    # Simulation units - use concentration='molecules' for
+    # molecule counts.
+    SimulationUnits(concentration="molecules", time="s")
+
+    # Physical and geometric constants
+    Unit(Parameter("f", 0.01), None)  # scaling factor
+
+    # Set the volume for molar concentrations to molecules
+    set_molecule_volume(f.value * 100.0, "pL")
+
+    # Initial concentrations
+    Parameter("EGF0", 2.0, unit="nM")
+    Parameter("EGFR0", f.value * 1.8e5, unit="molecules")
+
+    # Rate constants
+    Parameter("kp1", 9.0e7, unit="1/(M*s)")
+    Parameter("km1", 0.06, unit="1/s")
+
+    # Monomers
+    Monomer("EGF", ["R"])
+    Monomer("EGFR", ["L", "CR1", "Y1068"], {"Y1068": ["U", "P"]})
+
+    # Initial conditions
+    Initial(EGF(R=None), EGF0)
+    Initial(EGFR(L=None, CR1=None, Y1068="U"), EGFR0)
+
+    # Rules
+    Rule("egf_binds_egfr", EGF(R=None) + EGFR(L=None) | EGF(R=1) % EGFR(L=1), kp1, km1)
+
+    # Species LR EGF(R!1).EGFR(L!1)
+    Observable("Lbound", EGF(R=ANY))  # Molecules
+
+
+if __name__ == "__main__":
+    print(__doc__, "\n", model)
+    print(
+        """
+NOTE: This model code is designed to be imported and programatically
+manipulated, not executed directly. The above output is merely a
+diagnostic aid."""
+    )

--- a/src/pysb/units/examples/jnk3_no_ask1.py
+++ b/src/pysb/units/examples/jnk3_no_ask1.py
@@ -1,0 +1,262 @@
+"""Updated version of the jnk3_no_ask1 model from JARM with units.
+
+Units features are from the pysb-units add-on.
+
+Adapted from:
+https://github.com/LoLab-MSM/JARM/blob/master/model_analysis/jnk3_no_ask1.py
+"""
+
+from pysb import *
+from pysb.units import units
+
+# Define the model inside the units context for
+# pysb.units features. This includes SimulationUnits and Unit objects and
+# the set_molecule_volume function. Upon exiting the units context the
+# pysb.units.check function is executed to evaluate any potential issues with
+# the units, including checking for duplicate Unit objects, unit consistency,
+# or potentially missing units).
+with units():
+    Model()
+
+    # Simulation units - concentration in micromolar and 
+    # time in seconds.
+    SimulationUnits(concentration="uM", time="s")
+
+    # Declaring the monomers of the model
+    Monomer('Arrestin', ['b1', 'b2', 'b3'])
+    Monomer('MKK4', ['b', 'state'], {'state': ['U', 'P']})
+    Monomer('MKK7', ['b', 'state'], {'state': ['U', 'P']})
+    Monomer('JNK3', ['b', 'threo', 'tyro'], {'threo': ['U', 'P'], 'tyro': ['U', 'P']})
+
+    
+
+    # Because the Ordinary differential equations derived from the mass action kinetics law requires rate
+    # constants instead of K_D values, K_D values are going to be converted into rate parameters (k_r/k_f).
+    # We are going to assume that the reaction rate k_f is 'the average enzyme', whereas the k_r would be allowed to vary
+    # The forward reaction is association; the reverse is disassociation
+
+    ###### IMPORTANT INFO ABOUT JNK3
+
+    # pMKK4 with Arrestin-3, K_D = 347 microM, figure 1.B
+    Parameter('kf_pMKK4_Arr', 2, unit='1/(uM * s)')
+    Parameter('kr_pMKK4_Arr', 240, unit='1/s')
+
+    # pMKK7 with Arrestin-3, K_D = 13 microM, figure 1.D
+    Parameter('kf_pMKK7_Arr', 2, unit='1/(uM * s)')
+    Parameter('kr_pMKK7_Arr', 26, unit='1/s')
+
+    # Arrestin3-MKK4 bind to uuJNK3, K_D = 1.4 microM, figure 1.E
+    Parameter('kf_MKK4_Arr_bind_uuJNK3', 2, unit='1/(uM * s)')
+    Parameter('kr_MKK4_Arr_bind_uuJNK3', 2.8, unit='1/s')
+
+    # Arrestin3 bind to upJNK3, K_D = 4.2 microM, figure 1.F
+    Parameter('kf_upJNK3BindArr', 2, unit='1/(uM * s)')
+    Parameter('kr_upJNK3BindArr', 20, unit='1/s')
+
+    Parameter('kf_upJNK3_bind_Arr_MKK4', 2, unit='1/(uM * s)')
+    Parameter('kr_upJNK3_bind_Arr_MKK4', 8.4, unit='1/s')
+
+    Parameter('kf_upJNK3_bind_Arr_MKK7', 2, unit='1/(uM * s)')
+    Parameter('kr_upJNK3_bind_Arr_MKK7', 8.4, unit='1/s')
+
+    # Arrestin3 bind to puJNK3, K_D = 10.5 microM, figure 1.G
+    Parameter('kf_puJNK3BindArr', 2, unit='1/(uM * s)')
+    Parameter('kr_puJNK3BindArr', 20, unit='1/s')
+
+    Parameter('kf_puJNK3_bind_Arr_MKK4', 2, unit='1/(uM * s)')
+    Parameter('kr_puJNK3_bind_Arr_MKK4', 21, unit='1/s')
+
+    Parameter('kf_puJNK3_bind_Arr_MKK7', 2, unit='1/(uM * s)')
+    Parameter('kr_puJNK3_bind_Arr_MKK7', 21, unit='1/s')
+
+    # # ppJNK3 with Arrestin-3, K_D = 220 microM, figure 1.H
+    Parameter('kf_ppJNK3_Arr', 2, unit='1/(uM * s)')
+    Parameter('kr_ppJNK3_Arr', 32, unit='1/s')
+
+    # uuJNK3 binds Arrestin, K_D = 1.4 microM, figure 1.E
+    Parameter('kf_uuJNK3_Arr', 2, unit='1/(uM * s)')
+    Parameter('kr_uuJNK3_Arr', 2.2, unit='1/s')
+
+    ##### These are the parameters that are going to be calibrated
+
+    # Interacting JNK-docking Sites in MKK7 Promote Binding and
+    # Activation of JNK Mitogen-activated Protein Kinases* kd = 40 microm
+    Parameter('kf_MKK4BindArr_uuJNK3', 2, unit='1/(uM * s)')
+    Parameter('kr_MKK4BindArr_uuJNK3', 80, unit='1/s')
+
+    # Parameter('kf_MKK4BindArr_puJNK3', 2)
+    # Parameter('kr_MKK4BindArr_puJNK3', 80)
+
+    # kd = 30
+    Parameter('kf_MKK7BindArr_JNK3', 2, unit='1/(uM * s)')
+    Parameter('kr_MKK7BindArr_JNK3', 60, unit='1/s')
+
+    # Arrestin3-MKK7 bind to uuJNK3, K_D = 1.4 microM, Figure 1.E
+    Parameter('kf_MKK7_Arr_bind_uuJNK3', 2, unit='1/(uM * s)')
+    Parameter('kr_MKK7_Arr_bind_uuJNK3', 2.8, unit='1/s')
+
+    # uJNK3 with MKK4
+    Parameter('kf_MKK4_uuJNK3', 2, unit='1/(uM * s)')
+    Parameter('kr_MKK4_uuJNK3', 80, unit='1/s')
+
+    Parameter('kf_MKK4_puJNK3', 2, unit='1/(uM * s)')
+    Parameter('kr_MKK4_puJNK3', 80, unit='1/s')
+
+    # uJNK3 with MKK7
+    # This is when MKK7 is bound
+    Parameter('kf_MKK7_uuJNK3', 2, unit='1/(uM * s)')
+    Parameter('kr_MKK7_uuJNK3', 60, unit='1/s')
+
+    Parameter('kf_MKK7_upJNK3', 2, unit='1/(uM * s)')
+    Parameter('kr_MKK7_upJNK3', 60, unit='1/s')
+
+    # MKK4, Arrestin JNK3 activation
+    Parameter('kcat_pMKK4_ArrJNK3', 1, unit='1/s')
+
+    # MKK7, Arrestin JNK3 activation
+    Parameter('kcat_pMKK7_ArrJNK3', 1, unit='1/s')
+
+    Parameter('keq_pMKK4_to_pMKK7', 1, unit='1/(uM * s)')
+    Parameter('keq_pMKK7_to_pMKK4', 1, unit='1/(uM * s)')
+
+    Parameter('kf_pJNK3_MKK4complex', 2, unit='1/(uM * s)')
+    Parameter('kr_pJNK3_MKK4complex', 80, unit='1/s')
+
+    Parameter('kf_pJNK3_MKK7complex', 2, unit='1/(uM * s)')
+    Parameter('kr_pJNK3_MKK7complex', 60, unit='1/s')
+
+    # Initial conditions
+    Parameter('Arrestin_0', 5, unit='uM')
+    Parameter('pMKK4_0', 50., unit='nM')
+    Parameter('pMKK7_0', 50., unit='nM')
+    Parameter('uuJNK3_0', 0.593211087, unit='uM')
+    Parameter('puJNK3_0', 0, unit='uM')
+    Parameter('upJNK3_0', 6.788913, unit='nM')
+
+    Initial(Arrestin(b1=None, b2=None, b3=None), Arrestin_0)
+    Initial(MKK4(b=None, state='P'), pMKK4_0)
+    Initial(MKK7(b=None, state='P'), pMKK7_0)
+    Initial(JNK3(b=None, threo='U', tyro='U'), uuJNK3_0)
+    Initial(JNK3(b=None, threo='P', tyro='U'), puJNK3_0)
+    Initial(JNK3(b=None, threo='U', tyro='P'), upJNK3_0)
+
+    # Rules
+
+    # Arrestin interactions with MKK4/7 and JNK3
+
+    Rule('pMKK4BindArr', Arrestin(b1=None, b2=None, b3=None) + MKK4(b=None, state='P') |
+        Arrestin(b1=None, b2=2, b3=None) % MKK4(b=2, state='P'), kf_pMKK4_Arr, kr_pMKK4_Arr)
+
+    Rule('pMKK7BindArr', Arrestin(b1=None, b2=None, b3=None) + MKK7(b=None, state='P') |
+        Arrestin(b1=None, b2=2, b3=None) % MKK7(b=2, state='P'), kf_pMKK7_Arr, kr_pMKK7_Arr)
+
+    Rule('uuJNK3BindArr', Arrestin(b1=None, b2=None, b3=None) + JNK3(b=None, threo='U', tyro='U') |
+        Arrestin(b1=None, b2=None, b3=3) % JNK3(b=3, threo='U', tyro='U'), kf_uuJNK3_Arr, kr_uuJNK3_Arr)
+
+    Rule('upJNK3BindArr', Arrestin(b1=None, b2=None, b3=None) + JNK3(b=None, threo='U', tyro='P') |
+        Arrestin(b1=None, b2=None, b3=3) % JNK3(b=3, threo='U', tyro='P'), kf_upJNK3BindArr, kr_upJNK3BindArr)
+
+    Rule('puJNK3BindArr', Arrestin(b1=None, b2=None, b3=None) + JNK3(b=None, threo='P', tyro='U') |
+        Arrestin(b1=None, b2=None, b3=3) % JNK3(b=3, threo='P', tyro='U'), kf_puJNK3BindArr, kr_puJNK3BindArr)
+
+    # MKK4 interactions with JNK3 in the arrestin scaffold
+
+    Rule('MKK4_ArrBinduuJNK3', Arrestin(b1=None, b2=2, b3=None) % MKK4(b=2, state='P') + JNK3(b=None, threo='U', tyro='U') |
+        Arrestin(b1=None, b2=2, b3=3) % MKK4(b=2, state='P') % JNK3(b=3, threo='U', tyro='U'),
+        kf_MKK4_Arr_bind_uuJNK3, kr_MKK4_Arr_bind_uuJNK3)
+
+    Rule('MKK4catJNK3Arr', Arrestin(b1=None, b2=2, b3=3) % MKK4(b=2, state='P') % JNK3(b=3, tyro='U') >>
+        Arrestin(b1=None, b2=2, b3=3) % MKK4(b=2, state='P') % JNK3(b=3, tyro='P'),kcat_pMKK4_ArrJNK3)
+
+    # JNK3 has to get dissociated because otherwise it wouldnt be possible to have more pJNK3 than the value of MKK4 or MKK7
+    Rule('upJNK3Arr_MKK4_diss', Arrestin(b1=None, b2=2, b3=3) % MKK4(b=2, state='P') % JNK3(b=3,threo='U', tyro='P') |
+        Arrestin(b1=None, b2=2, b3=None) % MKK4(b=2, state='P') + JNK3(b=None, threo='U', tyro='P')
+        , kr_upJNK3_bind_Arr_MKK4, kf_upJNK3_bind_Arr_MKK4)
+
+    Rule('puJNK3Arr_MKK4_diss', Arrestin(b1=None, b2=2, b3=3) % MKK4(b=2, state='P') % JNK3(b=3, threo='P', tyro='U') |
+        Arrestin(b1=None, b2=2, b3=None) % MKK4(b=2, state='P') + JNK3(b=None, threo='P', tyro='U')
+        , kr_puJNK3_bind_Arr_MKK4, kf_puJNK3_bind_Arr_MKK4)
+
+    Rule('ppJNK3Arr_MKK4_diss', Arrestin(b1=None, b2=2, b3=3) % MKK4(b=2, state='P') % JNK3(b=3, threo='P', tyro='P') |
+        Arrestin(b1=None, b2=2, b3=None) % MKK4(b=2, state='P') + JNK3(b=None, threo='P', tyro='P')
+        , kr_ppJNK3_Arr, kf_ppJNK3_Arr)
+
+    # MKK7 interactions with JNK3 in the arrestin scaffold
+
+    Rule('MKK7_ArrBindUUJNK3', Arrestin(b1=None, b2=2, b3=None) % MKK7(b=2, state='P') + JNK3(b=None, threo='U', tyro='U') |
+        Arrestin(b1=None, b2=2, b3=3) % MKK7(b=2, state='P') % JNK3(b=3, threo='U', tyro='U')
+        , kf_MKK7_Arr_bind_uuJNK3, kr_MKK7_Arr_bind_uuJNK3)
+
+    Rule('MKK7catJNK3Arr', Arrestin(b1=None, b2=2, b3=3) % MKK7(b=2, state='P') % JNK3(b=3, threo='U') >>
+        Arrestin(b1=None, b2=2, b3=3) % MKK7(b=2, state='P') % JNK3(b=3, threo='P'), kcat_pMKK7_ArrJNK3)
+
+    # JNK3 has to get dissociated because otherwise it wouldnt be possible to have more pJNK3 than the value of MKK4 or MKK7
+    Rule('puJNK3Arr_MKK7_diss', Arrestin(b1=None, b2=2, b3=3) % MKK7(b=2, state='P') % JNK3(b=3, threo='P', tyro='U') |
+        Arrestin(b1=None, b2=2, b3=None) % MKK7(b=2, state='P') + JNK3(b=None, threo='P', tyro='U')
+        , kr_puJNK3_bind_Arr_MKK7, kf_puJNK3_bind_Arr_MKK7)
+
+    # Here we assume that the kinetics of puJNK3 disocciation for MKK4 are the same as for MKK7
+    Rule('upJNK3Arr_MKK7_diss', Arrestin(b1=None, b2=2, b3=3) % MKK7(b=2, state='P') % JNK3(b=3, threo='U', tyro='P') |
+        Arrestin(b1=None, b2=2, b3=None) % MKK7(b=2, state='P') + JNK3(b=None, threo='U', tyro='P')
+        , kr_upJNK3_bind_Arr_MKK7, kf_upJNK3_bind_Arr_MKK7)
+
+    Rule('ppJNK3Arr_MKK7_diss', Arrestin(b1=None, b2=2, b3=3) % MKK7(b=2, state='P') % JNK3(b=3, threo='P', tyro='P') |
+        Arrestin(b1=None, b2=2, b3=None) % MKK7(b=2, state='P') + JNK3(b=None, threo='P', tyro='P')
+        , kr_ppJNK3_Arr, kf_ppJNK3_Arr)
+
+    # MKK4/7 release from Arrestin complex
+    # We assume that MKK4/7 only binds to the Arr3:JNK3 complex when tyro/threo is unphosphorylated
+    Rule('MKK4DissArr_uuJNK3', Arrestin(b1=None, b2=None, b3=3) % JNK3(b=3, tyro='U') + MKK4(b=None, state='P')|
+        Arrestin(b1=None, b2=2, b3=3) % JNK3(b=3, tyro='U') % MKK4(b=2, state='P'), kf_MKK4BindArr_uuJNK3, kr_MKK4BindArr_uuJNK3)
+
+    # Rule('MKK4DissArr_puJNK3', Arrestin(b1=None, b2=None, b3=3) % JNK3(b=3, threo='P', tyro='U') + MKK4(b=None, state='P')|
+    #       Arrestin(b1=None, b2=2, b3=3) % JNK3(b=3, threo='P', tyro='U') % MKK4(b=2, state='P'), kf_MKK4BindArr_puJNK3, kr_MKK4BindArr_puJNK3)
+
+    Rule('MKK7DissArr_JNK3', Arrestin(b1=None, b2=None, b3=3) % JNK3(b=3, threo='U') + MKK7(b=None, state='P')|
+        Arrestin(b1=None, b2=2, b3=3) % JNK3(b=3, threo='U') % MKK7(b=2, state='P'), kf_MKK7BindArr_JNK3, kr_MKK7BindArr_JNK3)
+
+    # EquilibratePMKK4and7
+    Rule('EqpMKK4And7', Arrestin(b1=None, b2=2, b3=3) % MKK4(b=2, state='P') % JNK3(b=3, threo='U', tyro='P') + MKK7(b=None, state='P') >>
+        Arrestin(b1=None, b2=2, b3=3) % MKK7(b=2, state='P') % JNK3(b=3, threo='U', tyro='P') + MKK4(b=None, state='P'),
+        keq_pMKK4_to_pMKK7)
+
+    Rule('EqpMKK7And4', Arrestin(b1=None, b2=2, b3=3) % MKK7(b=2, state='P') % JNK3(b=3, threo='P', tyro='U') + MKK4(b=None, state='P') >>
+        Arrestin(b1=None, b2=2, b3=3) % MKK4(b=2, state='P') % JNK3(b=3, threo='P', tyro='U') + MKK7(b=None, state='P'),
+        keq_pMKK7_to_pMKK4)
+
+    #### Direct interactions between MKK4/7 and JNK3
+
+    Rule('MKK4BinduuJNK3', MKK4(b=None, state='P') + JNK3(b=None, threo='U', tyro='U') |
+        MKK4(b=1, state='P') % JNK3(b=1, threo='U', tyro='U')
+        , kf_MKK4_uuJNK3, kr_MKK4_uuJNK3)
+
+    Rule('MKK4BindpuJNK3', MKK4(b=None, state='P') + JNK3(b=None, threo='P', tyro='U') |
+        MKK4(b=1, state='P') % JNK3(b=1, threo='P', tyro='U')
+        , kf_MKK4_puJNK3, kr_MKK4_puJNK3)
+
+    # phosphorylation should be the same with of witouh arrestin as arrestin
+    # only organizes spatially the molecules but doesnt enhance the catalysis
+    Rule('MKK4catJNK3', MKK4(b=1, state='P') % JNK3(b=1, tyro='U') >>
+        MKK4(b=1, state='P') % JNK3(b=1, tyro='P'),kcat_pMKK4_ArrJNK3)
+
+    # JNK3 has to get dissociated because otherwise it wouldnt be possible to have more pJNK3 than the value of MKK4 or MKK7
+    Rule('pJNK3_MKK4complex_diss', MKK4(b=1, state='P') % JNK3(b=1, tyro='P') |
+        MKK4(b=None, state='P') + JNK3(b=None, tyro='P'), kr_pJNK3_MKK4complex, kf_pJNK3_MKK4complex)
+
+    Rule('MKK7BinduuJNK3', MKK7(b=None, state='P') + JNK3(b=None, threo='U', tyro='U') |
+        MKK7(b=1, state='P') % JNK3(b=1, threo='U', tyro='U'), kf_MKK7_uuJNK3, kr_MKK7_uuJNK3)
+
+    Rule('MKK7BindupJNK3', MKK7(b=None, state='P') + JNK3(b=None, threo='U', tyro='P') |
+        MKK7(b=1, state='P') % JNK3(b=1, threo='U', tyro='P'), kf_MKK7_upJNK3, kr_MKK7_upJNK3)
+
+    Rule('MKK7catJNK3', MKK7(b=1, state='P') % JNK3(b=1, threo='U') >>
+        MKK7(b=1, state='P') % JNK3(b=1, threo='P'), kcat_pMKK7_ArrJNK3)
+
+    # JNK3 has to get dissociated because otherwise it wouldnt be possible to have more pJNK3 than the value of MKK4 or MKK7
+    Rule('pJNK3_MKK7complex_diss', MKK7(b=1, state='P') % JNK3(b=1, threo='P') |
+        MKK7(b=None, state='P') + JNK3(b=None, threo='P'), kr_pJNK3_MKK7complex, kf_pJNK3_MKK7complex)
+
+    # Observables
+    Observable('pTyr_jnk3', JNK3(tyro='P'))
+    Observable('pThr_jnk3', JNK3(threo='P'))
+    Observable('all_jnk3', JNK3(tyro='P', threo='P'))

--- a/src/pysb/units/unitdefs.py
+++ b/src/pysb/units/unitdefs.py
@@ -74,7 +74,11 @@ equiv_molar_molecules = (molar, molec,
                          lambda x: np.round(x * _vol.value *  N_A.value, 0),
                          lambda x: x / (_vol.value * N_A.value)
                          )
-u.set_enabled_equivalencies([equiv_molar_molecules])
+equiv_molari_moleculesi = (molar**-1, molec**-1,
+                         lambda x: np.round(x / (_vol.value *  N_A.value), 0),
+                         lambda x: x * (_vol.value * N_A.value)
+                         )
+u.set_enabled_equivalencies([equiv_molar_molecules, equiv_molari_moleculesi])
 
 def set_molecule_volume(value = 1.0, unit = 'L'):
     input_unit = u.Unit(unit)
@@ -84,7 +88,11 @@ def set_molecule_volume(value = 1.0, unit = 'L'):
                          lambda x: np.round(x * _vol.value *  N_A.value, 0),
                          lambda x: x / (_vol.value * N_A.value)
                          )
-    u.set_enabled_equivalencies([equiv_molar_molecules])
+    equiv_molari_moleculesi = (molar**-1, molec**-1,
+                         lambda x: np.round(x / (_vol.value *  N_A.value), 0),
+                         lambda x: x * (_vol.value * N_A.value)
+                         )
+    u.set_enabled_equivalencies([equiv_molar_molecules, equiv_molari_moleculesi])
     return
 
 # Get a list of physical types that could be used


### PR DESCRIPTION
### Added
- New units context manager function `core.units` that allows users to load unit-based functionality and then run checks using context `from pysb.units import units; with units():`. The context manager applies the `unitize` and `check` functions automatically so users don't need to do it manually. 
- Optional `unit` argument for `Parameter` that allows unit specification when initializing a new model parameter: `Parameter(...,..., unit="...")` which is equivalent to `Unit(Parameter(..,..) "unit"))`.
- New `examples` sub-package with:
    - unit-ed version of `bngwiki_simple` model - adpated from `pysb.examples.bngwiki_simple`.
    - unit-ed version of the `jnk3_no_ask1` model - adpated from the `JARM/model_analysis/jnk3_no_ask1.py` model.

### Fixed
- Problem converting composite units with molar concentrations to their equivalent with number of molecules and updating the associated parameter. Updated the `ParameterUnit.convert` function to account for this.
- Problem in the string repr for Parameters with units set to `None`, as well as the processing in ParameterUnit that now skips the conversion related to `SimulationUnits` settings when the input unit is `None`. 